### PR TITLE
Fix issues #6, #10 and #11 of code.google.com/p/rpcz project and build failure with Boost 1.41

### DIFF
--- a/src/rpcz/reactor.cc
+++ b/src/rpcz/reactor.cc
@@ -108,7 +108,13 @@ long reactor::process_closure_run_map() {
   }
   long poll_timeout = -1;
   if (ub != closure_run_map_.end()) {
+// Since ZeroMQ 3, the zmp_poll's timeout is in milliseconds
+// In the previous version, the timeout was in microseconds      
+#if (ZMQ_VERSION_MAJOR >= 3)
+    poll_timeout = ub->first - now;
+#else
     poll_timeout = 1000 * (ub->first - now);
+#endif
   }
   closure_run_map_.erase(closure_run_map_.begin(), ub);
   return poll_timeout;

--- a/src/rpcz/rpc.cc
+++ b/src/rpcz/rpc.cc
@@ -46,9 +46,6 @@ int rpc::wait() {
   status_code status = get_status();
   CHECK_NE(status, status::INACTIVE)
       << "Request must be sent before calling wait()";
-  if (status != status::ACTIVE) {
-    return get_status();
-  }
   sync_event_->wait();
   return 0;
 }

--- a/src/rpcz/zsendrpc.cc
+++ b/src/rpcz/zsendrpc.cc
@@ -176,7 +176,12 @@ int main(int argc, char *argv[]) {
 
   desc.add_options()
       ("help", "produce help message")
+// the required() method is only avalaible since Boost 1.42
+#if (BOOST_VERSION <= 104100)
+      ("proto", po::value<std::string>(&FLAGS_proto),
+#else
       ("proto", po::value<std::string>(&FLAGS_proto)->required(),
+#endif
        "Protocol Buffer file to use.")
       ("proto_path", po::value<std::vector<std::string> >(&FLAGS_proto_path),
        "List of directories to search.")


### PR DESCRIPTION
Allows RPCZ to be build with Boost 1.41 and previous version
Fix following issues :
Issue 6: deadline_ms is expressed in seconds (https://code.google.com/p/rpcz/issues/detail?id=6)
Issue 10: Intermittent crash due to raise condition in rpc::wait() (https://code.google.com/p/rpcz/issues/detail?id=10)
Issue 11: deadline does not work with zeromq 3+ (https://code.google.com/p/rpcz/issues/detail?id=11)