### PR TITLE
Remove date_time dependency on Linux and add Windows installation instructions.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,14 +25,18 @@ endif()
 
 find_package(ProtobufPlugin REQUIRED)
 
-add_definitions(-DBOOST_ALL_NO_LIB)
-add_definitions(-DBOOST_ALL_DYN_LINK)
-add_definitions(-DBOOST_LIB_DIAGNOSTIC)
-set(Boost_USE_STATIC_LIBS OFF)
-set(Boost_USE_MULTITHREADED ON)
-set(Boost_USE_STATIC_RUNTIME OFF)
-
-find_package(Boost REQUIRED COMPONENTS thread program_options system date_time)
+if(WIN32)
+    add_definitions(-DBOOST_ALL_NO_LIB)
+    add_definitions(-DBOOST_ALL_DYN_LINK)
+    add_definitions(-DBOOST_LIB_DIAGNOSTIC)
+    set(Boost_USE_STATIC_LIBS OFF)
+    set(Boost_USE_MULTITHREADED ON)
+    set(Boost_USE_STATIC_RUNTIME OFF)
+    # date_time is required only on Windows
+    find_package(Boost REQUIRED COMPONENTS thread program_options system date_time)
+else()
+    find_package(Boost REQUIRED COMPONENTS thread program_options system)
+endif()
 
 find_package(ZeroMQ REQUIRED)
 
@@ -92,4 +96,3 @@ endif()
 if(CPACK_GENERATOR)
     include(CPack)
 endif(CPACK_GENERATOR)
-

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Introduction
 
   * The Python module is a [Cython](http://www.cython.org/) wrapper around the C++ API.
 
-  * RPCZ has been tested on Ubuntu 11.10 and Mac OS X Lion. I believe it should not be hard to get it to compile on Windows but I have not tried.
+  * RPCZ has been tested on Ubuntu 11.10, Ubuntu 14.04, Mac OS X Lion and Microsoft Visual Studio 2012.
 
 Quick Examples (API show off)
 -----------------------------
@@ -85,10 +85,10 @@ int main() {
 
 ```
 
-Getting Started: Installing
----------------------------
+Getting Started: Installing on Linux
+------------------------------------
 
-  * Make sure you have RPCZ's dependencies installed: Protocol Buffers (duh!), ZeroMQ, Boost (threads and program_options only), and CMake. If you are on Ubuntu:
+  * Make sure you have RPCZ's dependencies installed: Protocol Buffers (duh!), ZeroMQ, Boost (threads and program_options), and CMake. If you are on Ubuntu:
 ```bash
 apt-get install libprotobuf-dev libprotoc-dev libzmq-dev \
         libboost-thread-dev libboost-program-options-dev cmake
@@ -107,6 +107,16 @@ sudo make install
 
 You don't really have to `make install` if you don't want to. Just make sure that when you compile your code, your compiler is aware of RPCZ's include and library directories.
 
+  * Build Debian package:
+
+Instead of using `make install`, you can install RPCZ with the debian package. Once your build is completed, you can generate the debian package using:
+
+```bash
+make package
+```
+
+The package runtime dependencies have be tuned for Ubuntu 14.04 so YMMV. You can adapt these dependencies for your distribution by changing the `CPACK_DEBIAN_PACKAGE_DEPENDS` variable in the top-level `CMakeLists.txt` file.
+
   * Python support (optional):
 ```bash
 cd ../python
@@ -118,6 +128,27 @@ pip install -e .
 python setup.py build_ext -f --rpath=/path/to/build/src/rpcz
 pip install -e .
 ```
+
+Getting Started: Installing on Windows
+--------------------------------------
+
+First of all, on Windows it is recommended to build both release and debug configurations in order to avoid mixing runtime libraries. You will have to use the CMake GUI tool to generate the Microsoft Visual Studio project. There's many way to setup dependencies but here is a recipe that worked for me.
+
+* Boost installation
+   1. Download and install Boost binaries from the [sourceforge web page](http://sourceforge.net/projects/boost/). On windows, you will need `date_time` in addition to `threads` and `program_options`.
+   2. Set the `BOOST_ROOT` environment variable to the installation path used above.
+   3. Add the boost DLL directory to your `PATH` (e.g. `%BOOST_ROOT%\lib32-msvc-11.0`).
+* Google Protobuf installation
+   1. Download and extract the protobuf source package [protobuf-2.6.1.zip](https://github.com/google/protobuf/releases/download/v2.6.1/protobuf-2.6.1.zip) in the final installation directory.
+   2. Open the Visual Studio solution in the `vsprojects` subdirectory and build both debug and release configurations.
+   3. Set the `PROTOBUF_SRC_ROOT_FOLDER` environment variable to the protobuf directory used above.
+* ZeroMQ installation
+   1. Download and install the [ZeroMQ binaries](http://zeromq.org/distro:microsoft-windows).
+   2. Download the [ZeroMQ C++ bindings](https://github.com/zeromq/cppzmq) and copy the `zmq.hpp` header file in the `include` directory of ZeroMQ.
+   3. Set the `ZEROMQ_ROOT`environment variable to the installation path used above.
+   4. Add the ZeroMQ DLL directory to your `PATH` (e.g. `%ZEROMQ_ROOT%\bin`).
+
+Then, you are ready to configure and generate the Microsoft Visual Studio project using CMake.
 
 Generating Client and Server classes
 ------------------------------------

--- a/cmake_modules/FindProtobufPlugin.cmake
+++ b/cmake_modules/FindProtobufPlugin.cmake
@@ -208,7 +208,8 @@ if(MSVC)
     set(PROTOBUF_ORIG_FIND_LIBRARY_PREFIXES "${CMAKE_FIND_LIBRARY_PREFIXES}")
     set(CMAKE_FIND_LIBRARY_PREFIXES "lib" "")
 
-    find_path(PROTOBUF_SRC_ROOT_FOLDER protobuf.pc.in)
+    find_path(PROTOBUF_SRC_ROOT_FOLDER protobuf.pc.in
+              PATHS $ENV{PROTOBUF_SRC_ROOT_FOLDER})    
 endif()
 
 # The Protobuf library


### PR DESCRIPTION
- Boost date_time is required only on Windows so I removed it under Linux
- Force Boost dynamic linking only on Windows as Linux handles that intrinsically
- Add installation instructions for Windows and modify the Protobuf finder to work flawlessly on Windows
- Add instructions to generate the Debian package