### PR TITLE
Use proper cmake variables to link with Boost dependencies

### DIFF
--- a/src/rpcz/CMakeLists.txt
+++ b/src/rpcz/CMakeLists.txt
@@ -11,9 +11,7 @@ set(RPCZ_SOURCES
     ${PROTO_SOURCES})
 set(RPCZ_LIB_DEPS ${ZeroMQ_LIBRARIES}
                   ${PROTOBUF_LIBRARIES}
-                  ${Boost_THREAD_LIBRARIES}
-                  ${Boost_SYSTEM_LIBRARIES}
-                  ${Boost_DATE_TIME_LIBRARIES})
+                  ${Boost_LIBRARIES})
 
 if (RPCZ_ENABLE_IPV6)
 	set_source_files_properties(


### PR DESCRIPTION
To name a boost library one should use Boost_<C>_LIBARARY, not Boost_<C>_LIBRARIES,
see http://www.cmake.org/cmake/help/v3.0/module/FindBoost.html

Alternatively, Boost_LIBRARIES can be used to name all boost components previously listed in find_packages()