### PR TITLE
Fix dependencies for Debian package generation and modify README.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,18 @@ if(UNIX)
     # Debian package specific config
     set(CPACK_GENERATOR "DEB")
     set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Philippe Hamelin")
-    set(CPACK_DEBIAN_PACKAGE_DEPENDS "libzmq3, libprotobuf8, protobuf-compiler, protobuf-c-compiler")
+
+    # On recent Ubuntu versions, RPCZ may be build with either ZMQ 2 or 3
+    if(${ZMQ_VERSION_MAJOR} GREATER 2)
+        # Depends on ZMQ 3
+        set(CPACK_DEBIAN_ZEROMQ_DEPENDS "libzmq3")
+    else()
+        # Depends on ZMQ 2
+         set(CPACK_DEBIAN_ZEROMQ_DEPENDS "libzmq1")
+    endif()
+
+    set(CPACK_DEBIAN_PACKAGE_DEPENDS "${CPACK_DEBIAN_ZEROMQ_DEPENDS}, libprotobuf8, protobuf-compiler")
+
 elseif(WIN32)
     set(CPACK_GENERATOR "ZIP")
 endif()

--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ Getting Started: Installing on Linux
 
   * Make sure you have RPCZ's dependencies installed: Protocol Buffers (duh!), ZeroMQ, Boost (threads and program_options), and CMake. If you are on Ubuntu:
 ```bash
-apt-get install libprotobuf-dev libprotoc-dev libzmq-dev \
-        libboost-thread-dev libboost-program-options-dev cmake
+apt-get install libprotobuf-dev libprotoc-dev protobuf-compiler libzmq-dev \
+    libboost-thread-dev libboost-program-options-dev cmake
 ```
 
   * Download, build and install:


### PR DESCRIPTION
Fix Debian package dependencies in the CMake file. The generated debian package may now depends on either ZMQ v2 or ZMQ v3. Tested on Ubuntu 14.04.

Modify README to add missing protobuf-compiler package in Ubuntu dependencies.
